### PR TITLE
Update Dockerfile to use yarn start and add VSCode settings

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,4 +16,7 @@ COPY --from=builder /app/public ./public
 
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+#CMD ["node", "server.js"]
+
+
+CMD ["yarn", "start"]


### PR DESCRIPTION
Switch the command in the Dockerfile to use `yarn start` instead of `node server.js` for improved compatibility with Yarn.