### PR TITLE
Enhance analysis service with pull request retrieval and user data integration

### DIFF
--- a/backend/src/analysis/analysis.service.ts
+++ b/backend/src/analysis/analysis.service.ts
@@ -8,6 +8,7 @@ import { HttpService } from 'src/common/http/http.service'
 import { StructuredPRData } from 'src/common/interfaces/pr.interface'
 import { DatabaseService } from 'src/database/database.service'
 import { Status } from 'src/database/schemas/pull-request-analysis.schema'
+import { PRReviewDto } from 'src/github/dto/install-repo.dto'
 import { GithubEventService } from 'src/github/github-events.service'
 import { GitlabEventsService } from 'src/gitlab/gitlab-events.service'
 
@@ -38,9 +39,10 @@ export class AnalysisService {
                 prNumber: savedPullRequestFormattedData.prNumber,
                 installationId: savedPullRequestFormattedData.installationId,
                 status: Status.INPROGRESS,
-                startedAt: new Date()
+                startedAt: new Date(),
+                pullRequest: savedPullRequestFormattedData._id
             })
-        await this.httpService.post(
+        this.httpService.post(
             this.configService.get('AI_AGENT_PR_POST_URL') as string,
             {
                 pullRequest: {
@@ -49,9 +51,9 @@ export class AnalysisService {
                 }
             }
         )
-
         return {
-            pullRequestAnalysisId: pullRequestAnalysis['_id']
+            pullRequestAnalysisId: pullRequestAnalysis['_id'],
+            pullRequest: savedPullRequestFormattedData
         }
     }
 
@@ -150,6 +152,34 @@ export class AnalysisService {
         return {
             summary: postSummery.summary,
             status: 'added'
+        }
+    }
+
+    async getExistingPullRequestAndAnalysis(
+        prReviewDto: PRReviewDto,
+        provider: string
+    ) {
+        const pullRequestAnalysis =
+            await this.dataService.pullRequestAnalysis.findOne({
+                repositorySlug: prReviewDto.repo,
+                prNumber: prReviewDto.prNumber,
+                provider: provider
+            })
+        if (!pullRequestAnalysis) {
+            return false
+        }
+        return {
+            pullRequestAnalysisId: pullRequestAnalysis['_id'],
+            pullRequest: await this.dataService.pullRequests.findOne({
+                _id: pullRequestAnalysis.pullRequest
+            }),
+            pullRequestAnalysis: {
+                ...pullRequestAnalysis.toObject(),
+                comments:
+                    await this.dataService.pullRequestAnalysisComments.find({
+                        pullRequestAnalysisId: pullRequestAnalysis['_id']
+                    })
+            }
         }
     }
 

--- a/backend/src/bitbucket/bitbucket.service.ts
+++ b/backend/src/bitbucket/bitbucket.service.ts
@@ -185,6 +185,14 @@ export class BitbucketService {
     }
 
     async makePRReview(user: any, prReviewDto: PRReviewDto) {
+        const existingAnalysis =
+            await this.analysisService.getExistingPullRequestAndAnalysis(
+                prReviewDto,
+                'bitbucket'
+            )
+        if (existingAnalysis) {
+            return existingAnalysis
+        }
         const userData = await this.dataService.users
             .findOne({ _id: user.sub })
             .populate('currentWorkspace')

--- a/backend/src/database/schemas/pull-request-analysis.schema.ts
+++ b/backend/src/database/schemas/pull-request-analysis.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
-import { Document } from 'mongoose'
+import { Document, Types } from 'mongoose'
 import * as mongoosePaginate from 'mongoose-paginate-v2'
 import * as uniqueValidator from 'mongoose-unique-validator'
 
@@ -51,6 +51,17 @@ export class PullRequestAnalysis {
 
     @Prop({ type: Date, default: null })
     completedAt: Date
+
+    @Prop({
+        required: true,
+        type: Types.ObjectId,
+        ref: 'PullRequest',
+        set: (value) =>
+            Types.ObjectId.isValid(value)
+                ? value
+                : Types.ObjectId.createFromHexString(value)
+    })
+    pullRequest: Types.ObjectId
 }
 
 const schema = SchemaFactory.createForClass(PullRequestAnalysis)

--- a/backend/src/database/schemas/user.schema.ts
+++ b/backend/src/database/schemas/user.schema.ts
@@ -50,6 +50,7 @@ export class User {
                 : Types.ObjectId.createFromHexString(value)
     })
     currentWorkspace?: Types.ObjectId
+
     @Prop({
         type: [Types.ObjectId],
         ref: 'Workspace',

--- a/backend/src/github/github.controller.ts
+++ b/backend/src/github/github.controller.ts
@@ -90,6 +90,12 @@ export class GithubController {
         }
     }
 
+    @UseGuards(AuthGuard('jwt-cookie'))
+    @Get('org-members')
+    async getMembers(@Req() req: any) {
+        return this.githubService.getOrgMembers(req.user)
+    }
+
     @Post('events')
     async githubEvents(@Body() body: any, @Req() req) {
         const event = req.headers['x-github-event']

--- a/backend/src/github/github.service.ts
+++ b/backend/src/github/github.service.ts
@@ -216,6 +216,22 @@ export class GithubService {
         return prList
     }
 
+    async getUserDataWithWorkspace(user: any) {
+        const userData = await this.dataService.users
+            .findOne({ _id: user.sub })
+            .populate('currentWorkspace')
+        if (
+            !userData ||
+            !userData?.currentWorkspace ||
+            !userData?.currentWorkspace['installationId']
+        ) {
+            throw new Error(
+                'User or current workspace not found or installation ID missing'
+            )
+        }
+        return userData
+    }
+
     async listOrgRepositories(user: any) {
         const userData = await this.dataService.users
             .findOne({ _id: user.sub })
@@ -286,6 +302,14 @@ export class GithubService {
     }
 
     async makePRReview(user: any, prReviewDto: PRReviewDto) {
+        const existingAnalysis =
+            await this.analysisService.getExistingPullRequestAndAnalysis(
+                prReviewDto,
+                'github'
+            )
+        if (existingAnalysis) {
+            return existingAnalysis
+        }
         const userData = await this.dataService.users
             .findOne({ _id: user.sub })
             .populate('currentWorkspace')
@@ -317,6 +341,20 @@ export class GithubService {
             )
         }
         return await this.analysisService.makeAnalysis(pullRequestFormattedData)
+    }
+
+    async getOrgMembers(user: any) {
+        const userData = await this.getUserDataWithWorkspace(user)
+        const org = userData.currentWorkspace!['slug']
+        await this.initOctokit(user)
+        const members = await this.octokit.paginate(
+            this.octokit.orgs.listMembers,
+            {
+                org: org,
+                per_page: 100
+            }
+        )
+        return members
     }
 
     async processGithubEvent(event: any, payload: any) {

--- a/backend/src/gitlab/gitlab.service.ts
+++ b/backend/src/gitlab/gitlab.service.ts
@@ -225,6 +225,14 @@ export class GitlabService {
     }
 
     async makePRReview(user: any, prReviewDto: PRReviewDto) {
+        const existingAnalysis =
+            await this.analysisService.getExistingPullRequestAndAnalysis(
+                prReviewDto,
+                'gitlab'
+            )
+        if (existingAnalysis) {
+            return existingAnalysis
+        }
         const userData = await this.dataService.users
             .findOne({ _id: user.sub })
             .populate('currentWorkspace')


### PR DESCRIPTION
Improve the analysis service to retrieve existing pull requests and analyses from Bitbucket, GitLab, and GitHub. Extend the pull request analysis schema to include a reference to the associated pull request and add functionality to fetch user data with workspace details in the GitHub service.