### PR TITLE
Implement organization members retrieval for Bitbucket and GitLab services

### DIFF
--- a/backend/src/analysis/analysis.service.ts
+++ b/backend/src/analysis/analysis.service.ts
@@ -28,14 +28,8 @@ export class AnalysisService {
         const userData = await this.dataService.users
             .findOne({ _id: user.sub })
             .populate('currentWorkspace')
-        if (
-            !userData ||
-            !userData?.currentWorkspace ||
-            !userData?.currentWorkspace['installationId']
-        ) {
-            throw new Error(
-                'User or current workspace not found or installation ID missing'
-            )
+        if (!userData || !userData?.currentWorkspace) {
+            throw new Error('User or current workspace not found')
         }
         return userData
     }

--- a/backend/src/bitbucket/bitbucket-api.service.ts
+++ b/backend/src/bitbucket/bitbucket-api.service.ts
@@ -217,6 +217,37 @@ export class BitbucketApiService {
         return allPullRequests
     }
 
+    /**
+     * Get workspace members for Bitbucket
+     */
+    async getOrgMembers(
+        accessToken: string,
+        workspace: string
+    ): Promise<any[] | { error: string; message: string; members: any[] }> {
+        let allMembers: any[] = []
+        let url = `${this.baseUrl}/workspaces/${workspace}/members?pagelen=100`
+
+        const response = await this.httpService.get(url, {
+            headers: this.getAuthHeaders(accessToken)
+        })
+
+        if (response.values && Array.isArray(response.values)) {
+            response.values.forEach((member) => {
+                allMembers.push({
+                    provider: 'bitbucket',
+                    providerId: member.user?.uuid || member.uuid,
+                    username: member.user?.nickname,
+                    displayName:
+                        member.user?.display_name || member.display_name,
+                    avatarUrl:
+                        member.user?.links?.avatar?.href ||
+                        member.links?.avatar?.href
+                })
+            })
+        }
+        return allMembers
+    }
+
     async refreshAccessToken(refreshToken: string): Promise<{
         access_token: string
         refresh_token?: string

--- a/backend/src/bitbucket/bitbucket.controller.ts
+++ b/backend/src/bitbucket/bitbucket.controller.ts
@@ -85,6 +85,15 @@ export class BitbucketController {
     }
 
     @UseGuards(AuthGuard('jwt-cookie'))
+    @Get('org-members')
+    async getMembers(@Req() req: any) {
+        return {
+            message: 'Organization members fetched successfully',
+            result: await this.bitbucketService.getOrgMembers(req.user)
+        }
+    }
+
+    @UseGuards(AuthGuard('jwt-cookie'))
     @Post('add-webhook')
     async addWebhook(@Body() addWebhookDto: AddWebhookDto, @Req() req: any) {
         return {

--- a/backend/src/bitbucket/bitbucket.service.ts
+++ b/backend/src/bitbucket/bitbucket.service.ts
@@ -220,4 +220,14 @@ export class BitbucketService {
         }
         return await this.analysisService.makeAnalysis(pullRequestFormattedData)
     }
+
+    async getOrgMembers(user: any) {
+        const userData =
+            await this.analysisService.getUserDataWithWorkspace(user)
+
+        return await this.bitbucketApiService.getOrgMembers(
+            userData.accessToken as string,
+            userData?.currentWorkspace!['name'] as string
+        )
+    }
 }

--- a/backend/src/gitlab/gitlab-api.service.ts
+++ b/backend/src/gitlab/gitlab-api.service.ts
@@ -500,4 +500,40 @@ export class GitlabApiService {
             project
         }
     }
+
+    /**
+     * Get group/project members for GitLab
+     */
+    async getOrgMembers(
+        accessToken: string,
+        groupId: string,
+        isProject: boolean = false
+    ): Promise<any[] | { error: string; message: string; members: any[] }> {
+        let allMembers: any[] = []
+
+        // GitLab API endpoint differs for groups vs projects
+        let url: string
+        if (isProject) {
+            url = `${this.baseUrl}/projects/${encodeURIComponent(groupId)}/members/all?per_page=100`
+        } else {
+            url = `${this.baseUrl}/groups/${encodeURIComponent(groupId)}/members/all?per_page=100`
+        }
+
+        const response = await this.httpService.get(url, {
+            headers: this.getAuthHeaders(accessToken)
+        })
+
+        if (Array.isArray(response)) {
+            response.forEach((member) => {
+                allMembers.push({
+                    provider: 'gitlab',
+                    providerId: member.id,
+                    username: member.username,
+                    displayName: member.name,
+                    avatarUrl: member.avatar_url
+                })
+            })
+        }
+        return allMembers
+    }
 }

--- a/backend/src/gitlab/gitlab.controller.ts
+++ b/backend/src/gitlab/gitlab.controller.ts
@@ -101,4 +101,13 @@ export class GitlabController {
             result: reviewData
         }
     }
+
+    @UseGuards(AuthGuard('jwt-cookie'))
+    @Get('org-members')
+    async getMembers(@Req() req: any) {
+        return {
+            message: 'Organization members fetched successfully',
+            result: await this.gitlabService.getOrgMembers(req.user)
+        }
+    }
 }

--- a/backend/src/gitlab/gitlab.service.ts
+++ b/backend/src/gitlab/gitlab.service.ts
@@ -258,4 +258,14 @@ export class GitlabService {
         }
         return await this.analysisService.makeAnalysis(pullRequestFormattedData)
     }
+
+    async getOrgMembers(user: any) {
+        const userData =
+            await this.analysisService.getUserDataWithWorkspace(user)
+
+        return await this.gitlabApiService.getOrgMembers(
+            userData.accessToken as string,
+            userData?.currentWorkspace!['name'] as string
+        )
+    }
 }


### PR DESCRIPTION
Add endpoints to retrieve organization members for both Bitbucket and GitLab, enhancing user data access. Update error handling for user data retrieval.