### PR TITLE
Update getPRAnalysisData to return false for missing analysis

### DIFF
--- a/backend/src/analysis/analysis.service.ts
+++ b/backend/src/analysis/analysis.service.ts
@@ -205,7 +205,7 @@ export class AnalysisService {
             _id: pullRequestAnalysisId
         })
         if (!analysis) {
-            throw new Error('Pull request analysis not found')
+            return false
         }
         return {
             ...analysis.toObject(),


### PR DESCRIPTION
Change the behavior of getPRAnalysisData to return false instead of throwing an error when the analysis is not found.