### PR TITLE
Fix parameter in getOrgMembers method

### DIFF
--- a/backend/src/bitbucket/bitbucket.service.ts
+++ b/backend/src/bitbucket/bitbucket.service.ts
@@ -244,7 +244,7 @@ export class BitbucketService {
 
         return await this.bitbucketApiService.getOrgMembers(
             userData.accessToken as string,
-            userData?.currentWorkspace!['name'] as string
+            userData?.currentWorkspace!['slug'] as string
         )
     }
 }


### PR DESCRIPTION
Change the parameter from 'name' to 'slug' in the getOrgMembers method to ensure correct functionality.