### PR TITLE
Refactor response handling in fetch methods for consistency

### DIFF
--- a/backend/src/bitbucket/bitbucket-events.service.ts
+++ b/backend/src/bitbucket/bitbucket-events.service.ts
@@ -259,12 +259,13 @@ export class BitbucketEventsService {
 
             const apiUrl = `${bitbucketApiUrl}/repositories/${workspace}/${repository}/src/${commitSha}/${filePath}`
             console.log('Fetching file content from:', apiUrl)
-            return this.httpService.getWithHandleCatch(apiUrl, {
+            const response = await this.httpService.getWithHandleCatch(apiUrl, {
                 headers: {
                     Authorization: `Bearer ${accessToken}`,
                     Accept: 'text/plain'
                 }
             })
+            return String(response)
         } catch (error) {
             return null
         }

--- a/backend/src/gitlab/gitlab-events.service.ts
+++ b/backend/src/gitlab/gitlab-events.service.ts
@@ -248,7 +248,7 @@ export class GitlabEventsService {
                     }
                 }
             )
-            return response
+            return String(response)
         } catch (error) {
             return null
         }


### PR DESCRIPTION
Convert responses to strings in the `fetchPRFiles` and `fetchFileContent` methods to ensure consistent return types across services.