### PR TITLE
Refactor webhook addition in Bitbucket and Gitlab services

### DIFF
--- a/backend/src/bitbucket/bitbucket.service.ts
+++ b/backend/src/bitbucket/bitbucket.service.ts
@@ -107,10 +107,7 @@ export class BitbucketService {
         )
     }
 
-    async addWebhook(
-        userData: any,
-        repositories: RepositoryDto[]
-    ): Promise<any> {
+    async addWebhook(userData: any, repository: RepositoryDto): Promise<any> {
         const webhookUrl = `${this.configService.get('BASE_URL')}/v1/bitbucket/events`
         const events = [
             'repo:push',
@@ -124,20 +121,17 @@ export class BitbucketService {
             'issue:updated',
             'issue:comment_created'
         ]
-        const webhookPromises = repositories.map(async (repository) => {
-            const webhook = await this.bitbucketApiService.addWebhook(
-                userData?.accessToken as string,
-                userData?.currentWorkspace['slug'] as string,
-                repository.slug,
-                webhookUrl,
-                events
-            )
-            return {
-                ...repository,
-                webhookToken: webhook.id
-            }
-        })
-        return await Promise.all(webhookPromises)
+        const webhook = await this.bitbucketApiService.addWebhook(
+            userData?.accessToken as string,
+            userData?.currentWorkspace['slug'] as string,
+            repository.slug,
+            webhookUrl,
+            events
+        )
+        return {
+            ...repository,
+            webhookToken: webhook.id
+        }
     }
 
     async getPullRequests(user: any, getPRDto: GetPRDto) {

--- a/backend/src/database/schemas/repository.schema.ts
+++ b/backend/src/database/schemas/repository.schema.ts
@@ -42,9 +42,6 @@ export class Repository {
     @Prop({ required: false })
     updatedOn?: string
 
-    @Prop({ required: false })
-    webhookSecret?: string
-
     @Prop({ required: false, type: Object })
     author: Author
 

--- a/backend/src/gitlab/gitlab.service.ts
+++ b/backend/src/gitlab/gitlab.service.ts
@@ -130,10 +130,7 @@ export class GitlabService {
         )
     }
 
-    async addWebhook(
-        userData: any,
-        repositories: RepositoryDto[]
-    ): Promise<any> {
+    async addWebhook(userData: any, repository: RepositoryDto): Promise<any> {
         const webhookUrl = `${this.configService.get('BASE_URL')}/v1/gitlab/events`
         const events = [
             'push',
@@ -148,19 +145,16 @@ export class GitlabService {
             'release'
         ]
 
-        const webhookPromises = repositories.map(async (repository) => {
-            const webhook = await this.gitlabApiService.addWebhook(
-                userData?.accessToken,
-                repository.slug,
-                webhookUrl,
-                events
-            )
-            return {
-                ...repository,
-                webhookToken: webhook.id
-            }
-        })
-        return await Promise.all(webhookPromises)
+        const webhook = await this.gitlabApiService.addWebhook(
+            userData?.accessToken,
+            repository.slug,
+            webhookUrl,
+            events
+        )
+        return {
+            ...repository,
+            webhookToken: webhook.id
+        }
     }
 
     async handleOAuthCallback(code: string): Promise<any> {

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -18,6 +18,29 @@ export class WorkspaceService {
         private readonly bitbucketService: BitbucketService
     ) {}
 
+    async setWebhook(userData, repository) {
+        let repositoryData
+        switch (userData?.provider) {
+            case 'github':
+                repositoryData = repository
+                break
+            case 'gitlab':
+                repositoryData = await this.gitlabService.addWebhook(
+                    userData,
+                    repository
+                )
+                break
+            case 'bitbucket':
+                repositoryData = await this.bitbucketService.addWebhook(
+                    userData,
+                    repository
+                )
+                break
+            default:
+                throw new Error('Unsupported provider')
+        }
+        return repositoryData
+    }
     async makeSubscription(
         makeSubscriptionDto: MakeSubscriptionDto,
         user: any
@@ -25,25 +48,7 @@ export class WorkspaceService {
         const userData =
             await this.analysisService.getUserDataWithWorkspace(user)
         let repositories = makeSubscriptionDto.repositories
-        switch (userData?.provider) {
-            case 'github':
-                repositories = makeSubscriptionDto.repositories
-                break
-            case 'gitlab':
-                repositories = await this.gitlabService.addWebhook(
-                    userData,
-                    makeSubscriptionDto.repositories
-                )
-                break
-            case 'bitbucket':
-                repositories = await this.bitbucketService.addWebhook(
-                    userData,
-                    makeSubscriptionDto.repositories
-                )
-                break
-            default:
-                throw new Error('Unsupported provider')
-        }
+
         Promise.all(
             repositories.map(async (repository) => {
                 let repositoryData =
@@ -53,15 +58,17 @@ export class WorkspaceService {
                         workspace: userData?.currentWorkspace!._id
                     })
                 if (!repositoryData) {
-                    repositoryData = await this.dataService.repositories.create(
-                        {
-                            ...repository,
-                            provider: userData.provider,
-                            workspace: userData?.currentWorkspace!._id,
-                            isActive: true
-                        }
-                    )
+                    repository = await this.setWebhook(userData, repository)
+                    await this.dataService.repositories.create({
+                        ...repository,
+                        provider: userData.provider,
+                        workspace: userData?.currentWorkspace!._id,
+                        isActive: true
+                    })
                 } else {
+                    if (!repositoryData.webhookToken) {
+                        repository = await this.setWebhook(userData, repository)
+                    }
                     await this.dataService.repositories.updateOne(
                         { _id: user._id },
                         {


### PR DESCRIPTION
Streamline the addition of webhooks by modifying the method to handle a single repository instead of multiple. Remove the unused `webhookSecret` property from the repository schema.