### PR TITLE
Enable morgan logging and fix repository ID assignment in WorkspaceService

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,7 +3,7 @@ import { NestFactory } from '@nestjs/core'
 import * as bodyParser from 'body-parser'
 import * as compression from 'compression'
 import helmet from 'helmet'
-// import * as morgan from 'morgan'
+import * as morgan from 'morgan'
 import { AppModule } from './app.module'
 
 async function bootstrap() {
@@ -22,7 +22,7 @@ async function bootstrap() {
         credentials: true
     }
 
-    // app.use(morgan('tiny'))
+    app.use(morgan('tiny'))
 
     // Increase request body size limit (default: 100kb)
     app.use(bodyParser.json({ limit: '10mb' })) // Set the limit as per needs

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -58,9 +58,8 @@ export class WorkspaceService {
                         provider: userData.provider,
                         workspace: userData?.currentWorkspace!._id
                     })
-                console.log('repositoryData', repositoryData)
-                repository['_id'] = repositoryData!._id // add the id for workspace webhook lookup
                 if (!repositoryData) {
+                    repository['_id'] = repositoryData!._id // add the id for workspace webhook lookup
                     repository = await this.setWebhook(userData, repository)
                     await this.dataService.repositories.create({
                         ...repository,


### PR DESCRIPTION
Enable morgan logging for improved request logging and correct the assignment of repository IDs in the WorkspaceService.