### PR TITLE
Refactor getProfile method in AuthService

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -65,20 +65,15 @@ export class AuthService {
 
     async getProfile(userId: any) {
         return await this.dataService.users
-            .findOne(
-                {
-                    _id: userId
-                },
-                'providerId provider username displayName email avatarUrl onboardingStep'
-            )
+            .findOne({
+                _id: userId
+            })
             .populate([
                 {
-                    path: 'currentWorkspace',
-                    select: 'name slug avatarUrl '
+                    path: 'currentWorkspace'
                 },
                 {
-                    path: 'workspaces',
-                    select: 'name slug avatarUrl workSpaceSetting'
+                    path: 'workspaces'
                 }
             ])
     }


### PR DESCRIPTION
Simplify the getProfile method by removing unnecessary fields from the findOne query and the populate options.