### PR TITLE
feat(BE): Add repositorySlug and joinedAt properties to schemas

### DIFF
--- a/backend/src/analysis/analysis.service.ts
+++ b/backend/src/analysis/analysis.service.ts
@@ -233,7 +233,8 @@ export class AnalysisService {
                         pullRequestAnalysisId:
                             Types.ObjectId.createFromHexString(
                                 postReviewDto.pullRequestAnalysisId
-                            )
+                            ),
+                        repositorySlug: analysis.repositorySlug
                     }
                 )
             })

--- a/backend/src/bitbucket/bitbucket.service.ts
+++ b/backend/src/bitbucket/bitbucket.service.ts
@@ -338,7 +338,8 @@ export class BitbucketService {
             return {
                 ...member,
                 _id: savedMember?._id ?? null,
-                isActive: Boolean(savedMember?.isActive)
+                isActive: Boolean(savedMember?.isActive),
+                joinedAt: savedMember?.joinedAt
             }
         })
 

--- a/backend/src/database/schemas/pull-request-analysis-comment.schema.ts
+++ b/backend/src/database/schemas/pull-request-analysis-comment.schema.ts
@@ -13,6 +13,9 @@ export interface Author {
 
 @Schema({ timestamps: true, versionKey: false })
 export class PullRequestAnalysisComment {
+    @Prop({ required: true, type: String })
+    repositorySlug: string
+
     @Prop({ required: true, type: String, index: true })
     filePath: string
 

--- a/backend/src/github/github.service.ts
+++ b/backend/src/github/github.service.ts
@@ -480,7 +480,8 @@ export class GithubService {
             return {
                 ...member,
                 _id: savedMember?._id ?? null,
-                isActive: Boolean(savedMember?.isActive)
+                isActive: Boolean(savedMember?.isActive),
+                joinedAt: savedMember?.joinedAt
             }
         })
 

--- a/backend/src/gitlab/gitlab.service.ts
+++ b/backend/src/gitlab/gitlab.service.ts
@@ -377,7 +377,8 @@ export class GitlabService {
             return {
                 ...member,
                 _id: savedMember?._id ?? null,
-                isActive: Boolean(savedMember?.isActive)
+                isActive: Boolean(savedMember?.isActive),
+                joinedAt: savedMember?.joinedAt
             }
         })
 


### PR DESCRIPTION
Enhance the PullRequestAnalysisComment schema by adding the repositorySlug property and include it in PR review comments. Additionally, introduce the joinedAt property in member responses across Bitbucket, GitHub, and GitLab services.