### PR TITLE
Add role assignment for members based on providerId in Bitbucket, GitHub, and GitLab services

### DIFF
--- a/backend/src/analysis/analysis.service.ts
+++ b/backend/src/analysis/analysis.service.ts
@@ -191,7 +191,11 @@ export class AnalysisService {
                 {
                     pullRequest: {
                         ...pullRequestFormattedData.pullRequest,
-                        pullRequestAnalysisId: pullRequestAnalysis['_id']
+                        pullRequestAnalysisId: pullRequestAnalysis['_id'],
+                        apiKey: repository?.workspace?.workspaceSetting?.apiKey,
+                        modelName: repository?.workspace?.workspaceSetting?.modelName,
+                        minSeverity: repository?.minSeverity,
+                        ignore: repository?.ignore
                     }
                 },
                 {
@@ -203,11 +207,7 @@ export class AnalysisService {
         }
         return {
             pullRequestAnalysisId: pullRequestAnalysis['_id'],
-            pullRequest: savedPullRequestFormattedData,
-            apiKey: repository?.workspace?.workspaceSetting?.apiKey,
-            modelName: repository?.workspace?.workspaceSetting?.modelName,
-            minSeverity: repository?.minSeverity,
-            ignore: repository?.ignore
+            pullRequest: savedPullRequestFormattedData
         }
     }
 

--- a/backend/src/bitbucket/bitbucket.service.ts
+++ b/backend/src/bitbucket/bitbucket.service.ts
@@ -266,7 +266,8 @@ export class BitbucketService {
             case 'pullrequest:fulfilled':
                 await this.analysisService.updatedPRState(
                     {
-                        repo: payload.repository.slug || payload.repository.name,
+                        repo:
+                            payload.repository.slug || payload.repository.name,
                         prNumber: payload.pullRequest?.id.toString(),
                         owner:
                             payload.repository.workspace?.slug ||
@@ -280,7 +281,8 @@ export class BitbucketService {
             case 'pullrequest:rejected':
                 await this.analysisService.updatedPRState(
                     {
-                        repo: payload.repository.slug || payload.repository.name,
+                        repo:
+                            payload.repository.slug || payload.repository.name,
                         prNumber: payload?.pullRequest?.id.toString(),
                         owner:
                             payload.repository.workspace?.slug ||
@@ -372,6 +374,11 @@ export class BitbucketService {
             return {
                 ...member,
                 _id: savedMember?._id ?? null,
+                role:
+                    savedMember?.role ||
+                    userData.providerId == member.providerId
+                        ? 'owner'
+                        : 'member',
                 isActive: Boolean(savedMember?.isActive),
                 joinedAt: savedMember?.joinedAt
             }

--- a/backend/src/github/github.service.ts
+++ b/backend/src/github/github.service.ts
@@ -481,6 +481,11 @@ export class GithubService {
             return {
                 ...member,
                 _id: savedMember?._id ?? null,
+                role:
+                    savedMember?.role ||
+                    userData.providerId == member.providerId
+                        ? 'owner'
+                        : 'member',
                 isActive: Boolean(savedMember?.isActive),
                 joinedAt: savedMember?.joinedAt
             }

--- a/backend/src/gitlab/gitlab.service.ts
+++ b/backend/src/gitlab/gitlab.service.ts
@@ -398,6 +398,11 @@ export class GitlabService {
             return {
                 ...member,
                 _id: savedMember?._id ?? null,
+                role:
+                    savedMember?.role ||
+                    userData.providerId == member.providerId
+                        ? 'owner'
+                        : 'member',
                 isActive: Boolean(savedMember?.isActive),
                 joinedAt: savedMember?.joinedAt
             }


### PR DESCRIPTION
Implement role assignment logic to designate members as 'owner' or 'member' based on their providerId across multiple services. This change enhances user role management within the application.