### PR TITLE
Fix pull request number format in event processing

### DIFF
--- a/backend/src/gitlab/gitlab.service.ts
+++ b/backend/src/gitlab/gitlab.service.ts
@@ -308,7 +308,7 @@ export class GitlabService {
                     await this.analysisService.updatedPRState(
                         {
                             repo: payload.project.path_with_namespace,
-                            prNumber: payload.object_attributes.id.toString(),
+                            prNumber: payload.object_attributes.iid.toString(),
                             owner:
                                 payload.project.namespace.path ||
                                 payload.project.path_with_namespace.split(


### PR DESCRIPTION
Update the pull request number format to use the correct identifier in the event processing logic.