### PR TITLE
Fix totalToken calculation during pack purchase

### DIFF
--- a/backend/src/pack/pack.service.ts
+++ b/backend/src/pack/pack.service.ts
@@ -58,13 +58,15 @@ export class PackService {
             remainingToken =
                 totalToken +
                 userData?.currentWorkspace?.currentPack?.remainingToken
+            totalToken =
+                totalToken + userData?.currentWorkspace?.currentPack?.totalToken
         }
 
         const purchasedPack = await this.dataService.purchasedPacks.create({
             workspace: userData?.currentWorkspace?._id,
             pack: purchasePlanDto.packId,
             amount: packData.price,
-            totalToken: packData.token,
+            totalToken: totalToken,
             remainingToken: remainingToken,
             title: packData.title
         })


### PR DESCRIPTION
Update the totalToken calculation to include the current pack's totalToken when processing a pack purchase.