### PR TITLE
Update webhook removal to use repository ID

### DIFF
--- a/backend/src/gitlab/gitlab-api.service.ts
+++ b/backend/src/gitlab/gitlab-api.service.ts
@@ -683,8 +683,6 @@ export class GitlabApiService {
         await this.httpService.delete(apiEndpoint, {
             headers: this.getAuthHeaders(accessToken)
         })
-
-        console.log('GitLab webhook removed successfully')
         return {
             message: 'Webhook successfully removed!',
             projectId,

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -440,7 +440,7 @@ export class WorkspaceService {
                 case 'gitlab':
                     await this.gitlabService.removeWebhook(
                         accessToken,
-                        repository.slug,
+                        repository.id,
                         repository.webhookToken
                     )
                     break


### PR DESCRIPTION
Change the webhook removal process to utilize the repository ID instead of the slug for improved accuracy and reliability.